### PR TITLE
Fix deprecation in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* *.egg *.egg-info venv


### PR DESCRIPTION
Otherwise we get the following error while trying to run tests:

```
Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
```